### PR TITLE
[Feat/#29] 오답노트 목록 퍼블리싱 

### DIFF
--- a/src/pages/home/components/scrollText/ScrollText.tsx
+++ b/src/pages/home/components/scrollText/ScrollText.tsx
@@ -52,7 +52,7 @@ const ScrollText = () => {
     >
       {renderLine('수학문제풀이를', inverseGradientOpacity)}
       {renderLine('단계별로 도와주는', combinedOpacityLine2)}
-      {renderLine('TOPHAT', combinedOpacityLine3)}
+      {renderLine('MAPI', combinedOpacityLine3)}
     </motion.div>
   );
 };

--- a/src/pages/home/components/sectionBottom/sectionBottom.css.ts
+++ b/src/pages/home/components/sectionBottom/sectionBottom.css.ts
@@ -5,7 +5,7 @@ const sectionBottomWrapper = style({
   position: 'relative',
   width: '100%',
   height: '108.8rem',
-  background: 'linear-gradient(180deg, rgb(130, 172, 255) 0%, #D7ECFF 85%)',
+  background: 'linear-gradient(180deg, #82acff 0%, #D7ECFF 85%)',
   overflow: 'hidden',
 });
 

--- a/src/pages/home/components/sectionBottom/sectionBottom.css.ts
+++ b/src/pages/home/components/sectionBottom/sectionBottom.css.ts
@@ -5,7 +5,7 @@ const sectionBottomWrapper = style({
   position: 'relative',
   width: '100%',
   height: '108.8rem',
-  background: 'linear-gradient(168deg, #D7ECFF 0%, #AFDAFF 86.66%)',
+  background: 'linear-gradient(180deg, rgb(130, 172, 255) 0%, #D7ECFF 85%)',
   overflow: 'hidden',
 });
 

--- a/src/pages/home/components/sectionTop/sectionTop.css.ts
+++ b/src/pages/home/components/sectionTop/sectionTop.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css';
-import { themeVars } from '@styles/theme.css';
 
 const sectionTopWrapper = style({
   position: 'relative',
@@ -9,7 +8,7 @@ const sectionTopWrapper = style({
 
   width: '100%',
   height: '249.8rem',
-  background: themeVars.color.main_gradient,
+  background: 'linear-gradient(180deg, #2150EC 0%,rgb(130, 172, 255) 100%)',
 });
 
 const iconPosition = style({

--- a/src/pages/home/components/sectionTop/sectionTop.css.ts
+++ b/src/pages/home/components/sectionTop/sectionTop.css.ts
@@ -8,7 +8,7 @@ const sectionTopWrapper = style({
 
   width: '100%',
   height: '249.8rem',
-  background: 'linear-gradient(180deg, #2150EC 0%,rgb(130, 172, 255) 100%)',
+  background: 'linear-gradient(180deg, #2150EC 0%,#82acff 100%)',
 });
 
 const iconPosition = style({

--- a/src/pages/my/My.tsx
+++ b/src/pages/my/My.tsx
@@ -85,7 +85,7 @@ const My = () => {
           <div
             className={styles.chipList}
             style={{
-              maxHeight: expanded ? 'none' : '6rem',
+              maxHeight: expanded ? 'none' : '8rem',
               overflow: 'hidden',
             }}
           >

--- a/src/pages/my/My.tsx
+++ b/src/pages/my/My.tsx
@@ -23,8 +23,8 @@ const My = () => {
     return [shuffled[0], shuffled[1] || shuffled[0]];
   }, []);
 
-  const particle1 = getKoreanParticle(randomChip1.label, '와과'); // '와' or '과'
-  const particle2 = getKoreanParticle(randomChip2.label, '을를'); // '을' or '를'
+  const particle1 = getKoreanParticle(randomChip1.label, '와과');
+  const particle2 = getKoreanParticle(randomChip2.label, '을를');
 
   const toggleExpand = () => setExpanded((prev) => !prev);
 

--- a/src/pages/my/my.css.ts
+++ b/src/pages/my/my.css.ts
@@ -2,6 +2,8 @@ import { themeVars } from '@styles/theme.css';
 import { style } from '@vanilla-extract/css';
 
 export const container = style({
+  paddingTop: '10.8rem',
+
   minHeight: '100%',
   background: 'linear-gradient(355deg, #FFF 48.23%, #BFD9FE 97.05%), #FFF',
   backgroundRepeat: 'no-repeat',

--- a/src/pages/my/my.css.ts
+++ b/src/pages/my/my.css.ts
@@ -13,7 +13,7 @@ export const container = style({
 export const title = style({
   display: 'flex',
   flexDirection: 'row',
-  padding: '5.2rem 0 0 3.6rem',
+  padding: '3.2rem 0 0 3.6rem',
 });
 
 export const name = style({

--- a/src/pages/reviewNotes/ReviewNotes.tsx
+++ b/src/pages/reviewNotes/ReviewNotes.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { IcExtract } from '@components/icons';
 import { useNavigate } from 'react-router-dom';
 import { routePath } from '@routes/routePath';
@@ -9,7 +9,6 @@ import * as styles from './reviewNotes.css';
 
 const ReviewNotes = () => {
   const navigate = useNavigate();
-  const loaderRef = useRef<HTMLDivElement>(null);
 
   const handleClick = (id: number) => {
     navigate(routePath.REVIEW_NOTE_DETAIL.replace(':id', id.toString()));
@@ -33,7 +32,7 @@ const ReviewNotes = () => {
     });
   }, [dummyCards]);
 
-  useInfiniteScroll(loaderRef, loadMore);
+  const loaderRef = useInfiniteScroll(loadMore);
 
   return (
     <div className={styles.reviewContainer}>

--- a/src/pages/reviewNotes/ReviewNotes.tsx
+++ b/src/pages/reviewNotes/ReviewNotes.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { IcExtract } from '@components/icons';
 import { useNavigate } from 'react-router-dom';
 import { routePath } from '@routes/routePath';
@@ -23,12 +23,17 @@ const ReviewNotes = () => {
 
   const [cards, setCards] = useState(dummyCards.slice(0, 10));
 
-  useInfiniteScroll(loaderRef, () => {
-    setCards((prev) => [
-      ...prev,
-      ...dummyCards.slice(prev.length, prev.length + 10),
-    ]);
-  });
+  const loadMore = useCallback(() => {
+    setCards((prev) => {
+      const nextSlice = dummyCards.slice(prev.length, prev.length + 10);
+      if (nextSlice.length === 0) {
+        return prev;
+      }
+      return [...prev, ...nextSlice];
+    });
+  }, [dummyCards]);
+
+  useInfiniteScroll(loaderRef, loadMore);
 
   return (
     <div className={styles.reviewContainer}>

--- a/src/pages/reviewNotes/ReviewNotes.tsx
+++ b/src/pages/reviewNotes/ReviewNotes.tsx
@@ -1,8 +1,35 @@
+import { useState, useRef } from 'react';
 import { IcExtract } from '@components/icons';
+import { ReviewCard } from '@components/reviewCard/reviewCard';
+import { useNavigate } from 'react-router-dom';
+import { routePath } from '@routes/routePath';
+import { useInfiniteScroll } from '@hooks/useInfiniteScroll';
 
 import * as styles from './reviewNotes.css';
 
 const ReviewNotes = () => {
+  const navigate = useNavigate();
+  const loaderRef = useRef<HTMLDivElement>(null);
+
+  const handleClick = (id: number) => {
+    navigate(routePath.REVIEW_NOTE_DETAIL.replace(':id', id.toString()));
+  };
+
+  const dummyCards = Array.from({ length: 100 }, (_, i) => ({
+    id: i + 1,
+    text: `카드 ${i + 1}`,
+    imageSrc: `https://picsum.photos/300/200?random=${i + 1}`,
+  }));
+
+  const [cards, setCards] = useState(dummyCards.slice(0, 10));
+
+  useInfiniteScroll(loaderRef, () => {
+    setCards((prev) => [
+      ...prev,
+      ...dummyCards.slice(prev.length, prev.length + 10),
+    ]);
+  });
+
   return (
     <div className={styles.reviewContainer}>
       <h1 className={styles.title}>오답노트</h1>
@@ -12,6 +39,19 @@ const ReviewNotes = () => {
       <p className={styles.pdfComment}>
         질문했던 문제를 골라 출력해서 다시 풀어봐요!
       </p>
+
+      <div className={styles.cardContainer}>
+        {cards.map((card) => (
+          <ReviewCard
+            key={card.id}
+            imageSrc={card.imageSrc}
+            text={card.text}
+            onClick={() => handleClick(card.id)}
+          />
+        ))}
+      </div>
+
+      <div ref={loaderRef} />
     </div>
   );
 };

--- a/src/pages/reviewNotes/ReviewNotes.tsx
+++ b/src/pages/reviewNotes/ReviewNotes.tsx
@@ -1,9 +1,9 @@
 import { useState, useRef } from 'react';
 import { IcExtract } from '@components/icons';
-import { ReviewCard } from '@components/reviewCard/reviewCard';
 import { useNavigate } from 'react-router-dom';
 import { routePath } from '@routes/routePath';
 import { useInfiniteScroll } from '@hooks/useInfiniteScroll';
+import ReviewCard from '@components/reviewCard/ReviewCard';
 
 import * as styles from './reviewNotes.css';
 

--- a/src/pages/reviewNotes/ReviewNotes.tsx
+++ b/src/pages/reviewNotes/ReviewNotes.tsx
@@ -15,7 +15,7 @@ const ReviewNotes = () => {
     navigate(routePath.REVIEW_NOTE_DETAIL.replace(':id', id.toString()));
   };
 
-  const dummyCards = Array.from({ length: 100 }, (_, i) => ({
+  const dummyCards = Array.from({ length: 50 }, (_, i) => ({
     id: i + 1,
     text: `카드 ${i + 1}`,
     imageSrc: `https://picsum.photos/300/200?random=${i + 1}`,

--- a/src/pages/reviewNotes/ReviewNotes.tsx
+++ b/src/pages/reviewNotes/ReviewNotes.tsx
@@ -1,5 +1,19 @@
+import { IcExtract } from '@components/icons';
+
+import * as styles from './reviewNotes.css';
+
 const ReviewNotes = () => {
-  return <div>오답노트목록</div>;
+  return (
+    <div className={styles.reviewContainer}>
+      <h1 className={styles.title}>오답노트</h1>
+      <button className={styles.pdfButton}>
+        <IcExtract width={20} height={20} /> 오답노트 PDF로 추출하기
+      </button>
+      <p className={styles.pdfComment}>
+        질문했던 문제를 골라 출력해서 다시 풀어봐요!
+      </p>
+    </div>
+  );
 };
 
 export default ReviewNotes;

--- a/src/pages/reviewNotes/reviewNotes.css.ts
+++ b/src/pages/reviewNotes/reviewNotes.css.ts
@@ -36,3 +36,11 @@ export const pdfComment = style({
   color: themeVars.color.gray500,
   ...themeVars.font.labelLarge,
 });
+
+export const cardContainer = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  padding: '4.8rem 0',
+  rowGap: '24px',
+  columnGap: '10px',
+});

--- a/src/pages/reviewNotes/reviewNotes.css.ts
+++ b/src/pages/reviewNotes/reviewNotes.css.ts
@@ -2,7 +2,8 @@ import { themeVars } from '@styles/theme.css';
 import { style } from '@vanilla-extract/css';
 
 export const reviewContainer = style({
-  padding: '3.2rem 3.6rem',
+  padding: '14rem 3.6rem 4.8rem',
+  background: themeVars.color.gray100,
 });
 
 export const title = style({
@@ -21,7 +22,7 @@ export const pdfButton = style({
   padding: ' 1.4rem 0',
   borderRadius: '15px',
 
-  border: `1px solid ${themeVars.color.gray100}`,
+  border: `1px solid ${themeVars.color.gray200}`,
   background: themeVars.color.white000,
   boxShadow: '0 0 10px 0 rgba(192, 198, 202, 0.10)',
 
@@ -40,7 +41,7 @@ export const pdfComment = style({
 export const cardContainer = style({
   display: 'grid',
   gridTemplateColumns: '1fr 1fr',
-  padding: '4.8rem 0',
+  padding: '4.8rem 0 0',
   rowGap: '24px',
   columnGap: '10px',
 });

--- a/src/pages/reviewNotes/reviewNotes.css.ts
+++ b/src/pages/reviewNotes/reviewNotes.css.ts
@@ -1,0 +1,38 @@
+import { themeVars } from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
+
+export const reviewContainer = style({
+  padding: '3.2rem 3.6rem',
+});
+
+export const title = style({
+  paddingBottom: '2.4rem',
+  color: themeVars.color.gray600,
+  ...themeVars.font.displayLarge,
+});
+
+export const pdfButton = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '0.8rem',
+  width: '100%',
+  padding: ' 1.4rem 0',
+  borderRadius: '15px',
+
+  border: `1px solid ${themeVars.color.gray100}`,
+  background: themeVars.color.white000,
+  boxShadow: '0 0 10px 0 rgba(192, 198, 202, 0.10)',
+
+  color: themeVars.color.point,
+  ...themeVars.font.headlineLarge,
+});
+
+export const pdfComment = style({
+  display: 'flex',
+  justifyContent: 'center',
+  paddingTop: '0.8rem',
+  color: themeVars.color.gray500,
+  ...themeVars.font.labelLarge,
+});

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -1,11 +1,14 @@
 import { Outlet, ScrollRestoration, useLocation } from 'react-router-dom';
 import Header from '@components/header/Header';
+import { routePath } from '@routes/routePath';
 
 const Layout = () => {
   const location = useLocation();
 
-  const noHeaderPaths = ['/login', '/signup'];
-  const showHeader = !noHeaderPaths.includes(location.pathname);
+  const noHeaderPaths = [routePath.LOGIN, routePath.SIGNUP];
+  const showHeader = !noHeaderPaths.some((path) =>
+    location.pathname.startsWith(path),
+  );
 
   return (
     <>

--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -1,22 +1,18 @@
-import { useNavigate } from 'react-router-dom';
-import { themeVars } from '@styles/theme.css';
 import { IcMainRect, IcMypage } from '@components/icons';
-import * as styles from '@components/header/header.css';
+import { useNavigate } from 'react-router-dom';
 import { routePath } from '@routes/routePath';
+import { themeVars } from '@styles/theme.css';
+
+import { headerWrapper } from './header.css';
 
 const Header = () => {
   const navigate = useNavigate();
-
-  const goHome = () => navigate(routePath.HOME);
-  const goMyPage = () => navigate(routePath.MY);
-
   return (
-    <div className={styles.headerWrapper}>
-      <button type="button" aria-label="홈페이지로 이동" onClick={goHome}>
+    <div className={headerWrapper}>
+      <button onClick={() => navigate(routePath.HOME)}>
         <IcMainRect width={100} height={36} color={themeVars.color.white000} />
       </button>
-
-      <button type="button" aria-label="마이페이지로 이동" onClick={goMyPage}>
+      <button onClick={() => navigate(routePath.MY)}>
         <IcMypage width={36} height={36} color={themeVars.color.white000} />
       </button>
     </div>

--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -2,17 +2,19 @@ import { IcMainRect, IcMypage } from '@components/icons';
 import { useNavigate } from 'react-router-dom';
 import { routePath } from '@routes/routePath';
 import { themeVars } from '@styles/theme.css';
-
-import { headerWrapper } from './header.css';
+import * as styles from '@components/header/header.css';
 
 const Header = () => {
+  const goHome = () => navigate(routePath.HOME);
+  const goMyPage = () => navigate(routePath.MY);
+
   const navigate = useNavigate();
   return (
-    <div className={headerWrapper}>
-      <button onClick={() => navigate(routePath.HOME)}>
+    <div className={styles.headerWrapper}>
+      <button type="button" aria-label="홈페이지로 이동" onClick={goHome}>
         <IcMainRect width={100} height={36} color={themeVars.color.white000} />
       </button>
-      <button onClick={() => navigate(routePath.MY)}>
+      <button type="button" aria-label="마이페이지로 이동" onClick={goMyPage}>
         <IcMypage width={36} height={36} color={themeVars.color.white000} />
       </button>
     </div>

--- a/src/shared/components/header/header.css.ts
+++ b/src/shared/components/header/header.css.ts
@@ -7,13 +7,9 @@ export const headerWrapper = style({
   padding: '6rem 2.4rem 1.2rem',
   alignItems: 'center',
   justifyContent: 'space-between',
-  position: 'sticky',
+  position: 'fixed',
   top: 0,
   width: '100%',
-
-  backgroundColor: 'rgba(116, 163, 255, 0.6)',
-  boxShadow: '0px 4px 4px rgba(182, 182, 182, 0.1)',
-  backdropFilter: 'blur(10px)',
-  WebkitBackdropFilter: 'blur(10px)',
+  backdropFilter: 'blur(5px)',
   zIndex: themeVars.zIndex.five,
 });

--- a/src/shared/components/reviewCard/ReviewCard.tsx
+++ b/src/shared/components/reviewCard/ReviewCard.tsx
@@ -1,0 +1,5 @@
+const reviewCard = () => {
+  return <div>reviewCard</div>;
+};
+
+export default reviewCard;

--- a/src/shared/components/reviewCard/ReviewCard.tsx
+++ b/src/shared/components/reviewCard/ReviewCard.tsx
@@ -7,12 +7,12 @@ interface ReviewCardProps {
   onClick?: () => void;
 }
 
-export function ReviewCard({
+const ReviewCard = ({
   imageSrc,
   text,
   selected = false,
   onClick,
-}: ReviewCardProps) {
+}: ReviewCardProps) => {
   return (
     <div
       className={`${styles.cardContainer} ${selected ? styles.cardSelected : ''}`}
@@ -25,6 +25,6 @@ export function ReviewCard({
       <div className={styles.textContainer}>{text}</div>
     </div>
   );
-}
+};
 
 export default ReviewCard;

--- a/src/shared/components/reviewCard/ReviewCard.tsx
+++ b/src/shared/components/reviewCard/ReviewCard.tsx
@@ -7,12 +7,12 @@ interface ReviewCardProps {
   onClick?: () => void;
 }
 
-export const ReviewCard: React.FC<ReviewCardProps> = ({
+export function ReviewCard({
   imageSrc,
   text,
   selected = false,
   onClick,
-}) => {
+}: ReviewCardProps) {
   return (
     <div
       className={`${styles.cardContainer} ${selected ? styles.cardSelected : ''}`}
@@ -25,4 +25,6 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
       <div className={styles.textContainer}>{text}</div>
     </div>
   );
-};
+}
+
+export default ReviewCard;

--- a/src/shared/components/reviewCard/ReviewCard.tsx
+++ b/src/shared/components/reviewCard/ReviewCard.tsx
@@ -1,5 +1,28 @@
-const reviewCard = () => {
-  return <div>reviewCard</div>;
-};
+import * as styles from './reviewCard.css';
 
-export default reviewCard;
+interface ReviewCardProps {
+  imageSrc: string;
+  text: string;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+export const ReviewCard: React.FC<ReviewCardProps> = ({
+  imageSrc,
+  text,
+  selected = false,
+  onClick,
+}) => {
+  return (
+    <div
+      className={`${styles.cardContainer} ${selected ? styles.cardSelected : ''}`}
+      onClick={onClick}
+    >
+      <img src={imageSrc} alt={text} className={styles.imageBackground} />
+      <div
+        className={`${styles.overlay} ${selected ? styles.overlaySelected : ''}`}
+      />
+      <div className={styles.textContainer}>{text}</div>
+    </div>
+  );
+};

--- a/src/shared/components/reviewCard/reviewCard.css.ts
+++ b/src/shared/components/reviewCard/reviewCard.css.ts
@@ -1,0 +1,50 @@
+import { themeVars } from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
+
+export const cardContainer = style({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'flex-end',
+  width: '100%',
+  height: '14.4rem',
+
+  border: `1px solid ${themeVars.color.gray200}`,
+  borderRadius: '8px',
+  overflow: 'hidden',
+  transition: 'all 0.3s ease',
+  cursor: 'pointer',
+});
+
+export const cardSelected = style({
+  borderColor: themeVars.color.point,
+});
+
+export const overlay = style({
+  position: 'absolute',
+  inset: 0,
+  transition: 'background-color 0.3s ease',
+  pointerEvents: 'none',
+});
+
+export const overlaySelected = style({
+  background: 'rgba(230, 242, 255, 0.50)',
+});
+
+export const imageBackground = style({
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+});
+
+export const textContainer = style({
+  position: 'absolute',
+  left: '0.8rem',
+  bottom: '0.8rem',
+  padding: '0.2rem 0.6rem',
+  textAlign: 'center',
+  borderRadius: '24px',
+  backgroundColor: 'rgba(255, 255, 255, 0.8)',
+  color: themeVars.color.gray600,
+  ...themeVars.font.headlineLarge,
+});

--- a/src/shared/hooks/useInfiniteScroll.ts
+++ b/src/shared/hooks/useInfiniteScroll.ts
@@ -1,11 +1,17 @@
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 export const useInfiniteScroll = (
-  loaderRef: React.RefObject<HTMLDivElement | null>,
   callback: () => void,
+  options?: IntersectionObserverInit,
 ) => {
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+
+  const refCallback = useCallback((el: HTMLDivElement | null) => {
+    setNode(el);
+  }, []);
+
   useEffect(() => {
-    if (!loaderRef.current) {
+    if (!node) {
       return;
     }
 
@@ -13,10 +19,14 @@ export const useInfiniteScroll = (
       if (entry.isIntersecting) {
         callback();
       }
-    });
+    }, options);
 
-    observer.observe(loaderRef.current);
+    observer.observe(node);
 
-    return () => observer.disconnect();
-  }, [loaderRef, callback]);
+    return () => {
+      observer.disconnect();
+    };
+  }, [node, callback, options]);
+
+  return refCallback;
 };

--- a/src/shared/hooks/useInfiniteScroll.ts
+++ b/src/shared/hooks/useInfiniteScroll.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+export const useInfiniteScroll = (
+  loaderRef: React.RefObject<HTMLDivElement | null>,
+  callback: () => void,
+) => {
+  useEffect(() => {
+    if (!loaderRef.current) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        callback();
+      }
+    });
+
+    observer.observe(loaderRef.current);
+
+    return () => observer.disconnect();
+  }, [loaderRef, callback]);
+};

--- a/src/shared/hooks/useInfiniteScroll.ts
+++ b/src/shared/hooks/useInfiniteScroll.ts
@@ -24,6 +24,9 @@ export const useInfiniteScroll = (
     observer.observe(node);
 
     return () => {
+      if (node) {
+        observer.unobserve(node);
+      }
       observer.disconnect();
     };
   }, [node, callback, options]);


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #29 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
오답노트 목록 뷰 만들었어요.
목록 상단에 pdf 추출 버튼이 위치하지만, 아직 기능 여부가 확실치 않아 만들기만 했어요.
목록이 한 줄에 2개씩 위치하게 만들었고 이미지, 단원명을 받아올 수 있게 만들었어요. 우선은 임시 이미지, 텍스트 넣었어요.
이미지, 단원명이 쓰여진 reviewCard를 만들었는데 카드가 디폴트, 선택됨 상태의 디자인이 있지만, 선택됨 기능이 확실치 않아 만들어만 두었어요. 
헤더를 반투명으로 만드는게 예뻐서 조금 수정했어요. 

## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->


## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive Review Notes page with card grid, infinite scrolling, detail navigation, and a PDF extraction button.
  * New Review Card component for visual card items and smoother selection visuals.

* **Style**
  * Header now fixed to top with lighter blur, no translucent background/shadow; header hiding extended to related sub-paths.
  * Adjusted My page paddings and taller chip list.
  * Updated scrolling text: third line now shows "MAPI."
  * Updated section gradients for top and bottom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->